### PR TITLE
resolved the hamburger bug for mobile devices.

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -2013,6 +2013,18 @@ body {
   padding-bottom: 0.5rem;
 }
 
+@media (max-width: 1023px) {
+  #navbarToggler span {
+    --tw-bg-opacity: 1;
+    background-color: rgb(17 25 40 / var(--tw-bg-opacity));
+  }
+
+  :is(.dark #navbarToggler span) {
+    --tw-bg-opacity: 1;
+    background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  }
+}
+
 .sticky #navbarToggler span {
   --tw-bg-opacity: 1;
   background-color: rgb(17 25 40 / var(--tw-bg-opacity));


### PR DESCRIPTION
Added a mobile media query that forces the hamburger toggler bars (#navbarToggler span) to have an explicit dark color on light mode and white on .dark mode (for screens ≤1023px), making the hamburger icon visible on mobile in both themes.