### PR TITLE
Add office address across all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -287,7 +287,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -468,6 +468,14 @@
         </div>
       </div>
     </div>
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
       <span class="absolute left-0 top-0 z-[-1]">

--- a/about.html
+++ b/about.html
@@ -589,6 +589,13 @@
             </ul>
           </div>
         </div>
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/civil-structural.html
+++ b/civil-structural.html
@@ -623,7 +623,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -874,6 +874,14 @@
         </div>
       </div>
     </div> -->
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
       <!-- <span class="absolute left-0 top-0 z-[-1]">

--- a/contact.html
+++ b/contact.html
@@ -224,7 +224,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -372,6 +372,13 @@
                 </a>
               </li>
             </ul>
+          </div>
+        </div>
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -624,7 +624,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -768,6 +768,13 @@
                 </a>
               </li>
             </ul>
+          </div>
+        </div>
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
           </div>
         </div>
       </div>

--- a/mechanical-piping.html
+++ b/mechanical-piping.html
@@ -573,7 +573,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -886,6 +886,14 @@
         </div>
       </div>
     </div> -->
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
       <!-- <span class="absolute left-0 top-0 z-[-1]">

--- a/process-engineering.html
+++ b/process-engineering.html
@@ -558,7 +558,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -826,6 +826,14 @@
         </div>
       </div>
     </div> -->
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
       <!-- <span class="absolute left-0 top-0 z-[-1]">

--- a/process-safety-management.html
+++ b/process-safety-management.html
@@ -440,7 +440,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -588,6 +588,14 @@
         </div>
       </div>
     </div>
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
 

--- a/project-management-consultancy.html
+++ b/project-management-consultancy.html
@@ -586,7 +586,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -899,6 +899,14 @@
         </div>
       </div>
     </div> -->
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
       <!-- <span class="absolute left-0 top-0 z-[-1]">

--- a/project.html
+++ b/project.html
@@ -438,7 +438,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -612,6 +612,14 @@
         </div>
       </div>
     </div>
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
 

--- a/relief-system-gap-analysis.html
+++ b/relief-system-gap-analysis.html
@@ -507,7 +507,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -820,6 +820,14 @@
         </div>
       </div>
     </div> -->
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
       <!-- <span class="absolute left-0 top-0 z-[-1]">

--- a/service.html
+++ b/service.html
@@ -354,7 +354,7 @@
                     Our Location
                   </h5>
                   <p class="text-base text-body-color dark:text-dark-6">
-                    Corpus Christi, Texas, USA
+                    711 N Carancahua St Suite 1614<br>Corpus Christi TX 78414
                   </p>
                 </div>
               </div>
@@ -502,6 +502,14 @@
         </div>
       </div>
     </div>
+        <div class="ud-footer-column-services">
+          <div class="mb-10 w-full">
+            <h4 class="mb-9 text-lg font-semibold text-white">Our Office</h4>
+            <p class="mb-3 text-base text-gray-7">711 N Carancahua St Suite 1614</p>
+            <p class="text-base text-gray-7">Corpus Christi TX 78414</p>
+          </div>
+        </div>
+
 
     <div>
 


### PR DESCRIPTION
Replaces generic "Corpus Christi, Texas, USA" with the full office
address (711 N Carancahua St Suite 1614, Corpus Christi TX 78414) in
all contact section location cards, and adds an "Our Office" column
to the footer on every page.

https://claude.ai/code/session_01VfArifgXxNFLrsqaZUuvr8